### PR TITLE
Emit stats to statsd.

### DIFF
--- a/lemma/__init__.py
+++ b/lemma/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mailgun Cryptographic Tools.
+"""

--- a/lemma/httpsign.py
+++ b/lemma/httpsign.py
@@ -9,6 +9,8 @@ import os
 import threading
 import time
 
+import lemma.metrics
+
 from cryptography.hazmat.primitives import constant_time
 from expiringdict import ExpiringDict
 
@@ -24,11 +26,11 @@ SHARED_SECRET = None
 NONCE_CACHE = None
 
 
-def initialize(keypath, cache_capacity=CACHE_CAPACITY,
-               cache_timeout=CACHE_TIMEOUT):
+def initialize(keypath, cache_capacity=CACHE_CAPACITY, cache_timeout=CACHE_TIMEOUT):
     """
-    Initializes module by loading a shared key as well as nonce cache. This
-    module can handle authenticating 5,000 requests/second, if you need to
+    Initializes module by loading a shared key as well as nonce cache.
+
+    This module can handle authenticating 5,000 requests/second, if you need to
     authenticate more requests than that, set the cache capacity and timeout
     accordingly.
     """
@@ -102,8 +104,9 @@ def sign_request(request_body,
     return timestamp, nonce, signature, SIGNATURE_VERSION
 
 
-def authenticate_request(timestamp, nonce, request_body, signature,
-    signature_version="2", http_verb=None, http_resource_uri=None, headers=None, key=None):
+@lemma.metrics._metrics
+def authenticate_request(timestamp, nonce, request_body, signature, signature_version="2",
+    http_verb=None, http_resource_uri=None, headers=None, key=None, metrics_prefix=None):
     """
     Given a timestamp, nonce, request body, signature, and optionally (signature_version,
     http_verb and http_resource_uri, headers, and key:
@@ -121,10 +124,12 @@ def authenticate_request(timestamp, nonce, request_body, signature,
     Returns a boolean.
     """
 
-    # if shared secret or nonce cache not loaded, don't authenticate anything
+    # if shared secret is not loaded, don't authenticate anything
     if not SHARED_SECRET:
         if not key:
             raise AuthenticationException('No shared secret provided.')
+
+    # if nonce cache not loaded, don't authenticate anything
     if NONCE_CACHE is None:
         raise AuthenticationException('Nonce cache not configured.')
 
@@ -145,6 +150,7 @@ def authenticate_request(timestamp, nonce, request_body, signature,
     # check the hmac
     if not _check_mac(shared_secret, timestamp, nonce, request_body, signature,
             http_verb=http_verb, http_resource_uri=http_resource_uri, headers=headers):
+
         return False
 
     # check timestamp

--- a/lemma/metrics.py
+++ b/lemma/metrics.py
@@ -1,10 +1,86 @@
 """
-Module emits metrics to a backend. Used to monitor for anomalous behavior.
-Just a stub for now.
+Module metrics provides methods used to emit real time metrics to statsd. This
+module requires that it be initialized before it can be used.
+
+>>> from lemma import metrics
+>>> metrics.init('localhost', 8125, 'lemma')
 """
+import statsd
+import socket
 
-def emit_success():
-    pass
+# module level statsd client instance: `statsd.StatsClient`. According to the
+# documentation this is thread safe.
+client = None
 
-def emit_failure():
-    pass
+# send all metrics by default
+DEFAULT_SAMPLE_RATE = 1
+
+
+def initialize(host, port, prefix=None):
+    """
+    Initialize statsd client. Metrics will be emitted to the provided host and
+    port. An optional prefix can also be passed in to be prepended to all metrics.
+    """
+    global client
+
+    # if no prefix is given, prefix it with lemma.machine_hostname
+    if not prefix:
+        hostname = socket.gethostname()
+        hostname.replace('.', '_')
+
+        prefix = 'lemma.{}'.format(hostname)
+
+    client = statsd.StatsClient(host, port, prefix=prefix)
+
+
+def emit_success(prefix=None):
+    """
+    Emits success metric to statsd. A prefix is required and should
+    reflect the component being monitored.
+
+    >>> import lemma.metrics
+    >>> lemma.metrics.emit_success('component.heartbeat')
+    """
+
+    if prefix:
+        _inc('{}.success'.format(prefix))
+        return
+    _inc('success')
+
+
+def emit_failure(prefix=None):
+    """
+    Emits failure metric to statsd. A prefix is required and
+    should reflect the component being monitored.
+
+    >>> import lemma.metrics
+    >>> lemma.metrics.emit_failure('component.signature')
+    """
+
+    if prefix:
+        _inc('{}.failure'.format(prefix))
+        return
+
+    _inc('failure')
+
+
+def _inc(stat, count=1, rate=DEFAULT_SAMPLE_RATE):
+    """
+    Increment a counter for a provided metric.
+    """
+
+    if not client:
+        return
+    client.incr(stat, count, rate)
+
+
+def _metrics(fn):
+    def wrapper(*arg, **kw):
+        try:
+            result = fn(*arg, **kw)
+            emit_failure() if result is False else emit_success()
+            return result
+        except:
+            emit_failure()
+            raise
+    return wrapper

--- a/lemma/secret.py
+++ b/lemma/secret.py
@@ -73,12 +73,12 @@ def initialize_with_key(keybytes=None):
     try:
         SECRET_KEY = keybytes
         BOX = nacl.secret.SecretBox(SECRET_KEY)
-    except Exception as e:
+    except:
         raise SecretException('Unable to initialize SecretBox with given '
             'key: {}: {}'.format(keybytes, e))
 
 
-def seal(plaintext, key=None, emit_metrics=True):
+def seal(plaintext, key=None):
     """
     Given some plaintext, seal will encrypt and MAC the resulting ciphertext.
     The ciphertext and a nonce is returned on successful encryption.
@@ -109,7 +109,8 @@ def seal(plaintext, key=None, emit_metrics=True):
     return encrypted_message.ciphertext, encrypted_message.nonce
 
 
-def open(ciphertext, nonce, key=None, emit_metrics=True):
+@lemma.metrics._metrics
+def open(ciphertext, nonce, key=None, metrics_prefix=None):
     """
     Given ciphertext and a nonce, open will authenticate that the ciphertext
     has not been tampered with and return the decrypted plaintext.
@@ -129,17 +130,9 @@ def open(ciphertext, nonce, key=None, emit_metrics=True):
     # open the box and retrieve the message
     try:
         plaintext = box.decrypt(ciphertext, nonce)
-    except nacl.exceptions.CryptoError as ce:
-        # emit failure metric
-        if emit_metrics:
-            lemma.metrics.emit_failure()
-
+    except:
         # raise the exception so we know what happened
         raise
-
-    # emit successful metric
-    if emit_metrics:
-        lemma.metrics.emit_success()
 
     return plaintext
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,9 @@ setup(name='pylemma',
           'mock'
       ],
       install_requires=[
-          'expiringdict>=1.1.3',
           'cryptography>=0.5.1',
+          'expiringdict>=1.1.3',
           'pynacl>=0.2.3',
+          'statsd>=3.0.1'
       ],
       )


### PR DESCRIPTION
**Purpose**

A good way to look for malicious activity is successful and unsuccessful authentication/encryption events. Currently we have no way of doing this. This commit starts emitting these metrics to statsd. This way we can display it on a dashbaord and if we see a spike of unsuccessful authentication or encryption events we know someone may be trying to attack our system or something is going wrong on our end.

**Implementation**
- Before doing anything else, call `lemma.metrics.initialize` with the hostname and port of the statsd server. Optionally a prefix can be given to prefix all metrics. By deafult this is `lemma.{hostname}`.
- If you don't call `lemma.metrics.initialize` you can still call the `emit_success` and `emit_failure` methods, but nothing will happen. This is done to keep code clean, so instead of a `if` check every time you want to emit a metric, you can just try to emit the metric. It will be sent if you have the service configured. 
- Call `lemma.metrics.emit_success` or `lemma.metrics.emit_failure` whenever you wish to emit a  `Counter` metric. They are thread safe.
- Currently, the above two methods are only called by `lemma.httpsign.authenticate_request` and `lemma.httpsign.open`.

**Related Commits**
https://github.com/mailgun/lemma/pull/2
