### PR TITLE
Increase timeout period.

### DIFF
--- a/lemma/httpsign.py
+++ b/lemma/httpsign.py
@@ -13,9 +13,9 @@ from cryptography.hazmat.primitives import constant_time
 from expiringdict import ExpiringDict
 
 # constants
-MAX_SKEW_SEC = 5  # 5 sec
-CACHE_TIMEOUT = 30  # 30 sec
-CACHE_CAPACITY = 5000 * CACHE_TIMEOUT  # 5,000 msg/sec * 30 sec = 150,000 msg
+MAX_SKEW_SEC = 5 # 5 sec
+CACHE_TIMEOUT = 100  # 30 sec
+CACHE_CAPACITY = 5000 * CACHE_TIMEOUT  # 5,000 msg/sec * 100 sec = 500,000 msg
 SIGNATURE_VERSION = "2"
 
 # module level variables


### PR DESCRIPTION
**Purpose**

Traffic on the internet can often take much longer than 10 seconds to transmit. This is especially so if large messages are being sent. This commit increases that timeout to 95 seconds so even large messages should fall within the acceptable window.

**Implementation**

Looking at the `check_timestamp` function in `lemma.httpsign`, imagine you are at some time `t`. The request can not be from more than `t + MAX_SKEW_SEC` in the future. The request can also not be from more than `t - (CACHE_TIMEOUT - MAX_SKEW_SEC)` in the past. Therefore, if we want to allow a 95 second window, we have to increase `CACHE_TIMEOUT` and/or decrease `MAX_SKEW_SEC`.

This was done by changing the constants, `CACHE_TIMEOUT` is now `100 seconds` and `MAX_SKEW_SEC` is `5 seconds`.

**Related Commit**
https://github.com/mailgun/lemma/pull/3
