### PR TITLE
Fixed broken tests that were not updated after timeouts changed.

### DIFF
--- a/lemma/httpsign.py
+++ b/lemma/httpsign.py
@@ -16,7 +16,7 @@ from expiringdict import ExpiringDict
 
 # constants
 MAX_SKEW_SEC = 5 # 5 sec
-CACHE_TIMEOUT = 100  # 30 sec
+CACHE_TIMEOUT = 100  # 100 sec
 CACHE_CAPACITY = 5000 * CACHE_TIMEOUT  # 5,000 msg/sec * 100 sec = 500,000 msg
 SIGNATURE_VERSION = "2"
 

--- a/tests/httpsign_test.py
+++ b/tests/httpsign_test.py
@@ -177,14 +177,14 @@ def test_check_timestamp(tm):
     {
         # old timestamp
         "input": {
-            "timestamp": "1330837517",
+            "timestamp": "1330837467",
         },
         "output": False
     },
     {
         # timestamp from future
         "input": {
-            "timestamp": "1330837587",
+            "timestamp": "1330837578",
         },
         "output": False
     }]
@@ -230,7 +230,7 @@ def test_check_nonce(tm):
         # aged off first value, should not be in cache.
         "input": {
             "nonce": "0",
-            "mock_time": 1330837597,
+            "mock_time": 1330837667,
         },
         "output": False
     }]


### PR DESCRIPTION
**Purpose**

Tests were broken after we updated the `CACHE_TIMEOUT` and `MAX_SKEW_SEC`. Fixed values to test against.

**Implementation**
- Fixed `test_check_timestamp` and `test_check_nonce` by increasing/decreasing the value of `timestamp`.
